### PR TITLE
Dev

### DIFF
--- a/internal/build-constants/src/config.ts
+++ b/internal/build-constants/src/config.ts
@@ -2,7 +2,6 @@ import { LIB_ALIAS, LIB_NAME } from './name'
 
 export const libExternal = [
   'vue',
-  'echarts',
   new RegExp(`^${LIB_NAME}`),
   new RegExp(`^${LIB_ALIAS}`),
 ]

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@vunk-markdown/components": "workspace:*",
     "@vunk-markdown/composables": "workspace:*",
     "@vunk-markdown/shared": "workspace:*",
-    "@vunk/core": "1.5.4",
+    "@vunk/core": "1.6.1",
     "@vunk/echarts": "^0.0.3",
     "@vunk/form": "2.9.1",
     "@vunk/markdown": "workspace:*",

--- a/packages/components/gulpfile.ts
+++ b/packages/components/gulpfile.ts
@@ -1,15 +1,18 @@
-import { parallel } from 'gulp'
-import path from 'path'
-import { sync } from 'fast-glob'
-import { distDir } from '@lib-env/path'
+import path from 'node:path'
 import { filePathIgnore } from '@lib-env/build-constants'
 import { genTypes, rollupFiles } from '@lib-env/build-utils'
-import { gulpTask } from '@vunk/shared/function'
+import { distDir } from '@lib-env/path'
 import { createTsPlugins, createVuePlugins } from '@vunk/shared/build/rollup/plugins'
+import { gulpTask } from '@vunk/shared/function'
+import { sync } from 'fast-glob'
+import { parallel } from 'gulp'
 
 const buildFile = '**/index.ts'
 const baseDirname = __dirname.split(path.sep).pop() as string
-const external = []
+const external = [
+  'mermaid',
+  'echarts',
+]
 
 const filePaths = sync(buildFile, {
   cwd: path.resolve(__dirname, './'),
@@ -37,4 +40,3 @@ export default parallel(
     })
   }),
 )
-

--- a/packages/entry/package.json
+++ b/packages/entry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vunk/markdown",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "",
   "author": "EralChen",
   "license": "MIT",

--- a/packages/entry/package.json
+++ b/packages/entry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vunk/markdown",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "",
   "author": "EralChen",
   "license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 0.0.0-alpha.76
       '@vuesri/core':
         specifier: ^2.0.0
-        version: 2.0.0(@arcgis/core@4.32.10)(@vunk/core@1.5.4)(vue@3.5.16(typescript@5.8.3))
+        version: 2.0.0(@arcgis/core@4.32.10)(@vunk/core@1.6.1)(vue@3.5.16(typescript@5.8.3))
       '@vuesri/three':
         specifier: 0.0.4
         version: 0.0.4
@@ -42,8 +42,8 @@ importers:
         specifier: workspace:*
         version: link:packages/shared
       '@vunk/core':
-        specifier: 1.5.4
-        version: 1.5.4
+        specifier: 1.6.1
+        version: 1.6.1
       '@vunk/echarts':
         specifier: ^0.0.3
         version: 0.0.3
@@ -2790,8 +2790,8 @@ packages:
   '@vueuse/shared@9.13.0':
     resolution: {integrity: sha512-UrnhU+Cnufu4S6JLCPZnkWh0WwZGUp72ktOF2DFptMlOs3TOdVv8xJN53zhHGARmVOsz5KqOls09+J1NR6sBKw==}
 
-  '@vunk/core@1.5.4':
-    resolution: {integrity: sha512-kFi/wVXjWrqPHGjKxz7GL7Anc9eqJqfKIyotPKDobhmmSVS+s1BgxI9qZZS174Bcy1f1q23XOFbq3Lx6i5TAeA==}
+  '@vunk/core@1.6.1':
+    resolution: {integrity: sha512-Tdv/ZuQy3ExCP9rO6x1gJkgy4i0aw0S5w7ET5AvAflsYl5rXgQ6U3JnfUgpTPTv29V/wejgzPRMP3J1znOylMQ==}
 
   '@vunk/echarts@0.0.3':
     resolution: {integrity: sha512-0vXzQWTRfRCgh/mKZ7cqrhNOUg3Smvizm3NU7TScVbC9b1GN9mh+L59n5Gqti47qFAqDbigESS7mG6wV/EqqBA==}
@@ -2969,7 +2969,7 @@ packages:
     resolution: {integrity: sha512-7HhHjtERjqlNbZtqNqy2rckN/SpOOlmDliet+lP7k+eKZEjPk3DgyeU9lIXLdeLz0uBbbVp+9Qdow9wJWgwwfg==}
 
   asynckit@0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+    resolution: {integrity: sha1-x57Zf380y48robyXkLzDZkdLS3k=}
 
   atob@2.1.2:
     resolution: {integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==}
@@ -10139,11 +10139,11 @@ snapshots:
 
   '@vue/shared@3.5.16': {}
 
-  '@vuesri/core@2.0.0(@arcgis/core@4.32.10)(@vunk/core@1.5.4)(vue@3.5.16(typescript@5.8.3))':
+  '@vuesri/core@2.0.0(@arcgis/core@4.32.10)(@vunk/core@1.6.1)(vue@3.5.16(typescript@5.8.3))':
     dependencies:
       '@arcgis/core': 4.32.10
       '@vueuse/core': 10.11.1(vue@3.5.16(typescript@5.8.3))
-      '@vunk/core': 1.5.4
+      '@vunk/core': 1.6.1
       lodash-es: 4.17.21
       vue: 3.5.16(typescript@5.8.3)
     transitivePeerDependencies:
@@ -10234,7 +10234,7 @@ snapshots:
       - '@vue/composition-api'
       - vue
 
-  '@vunk/core@1.5.4': {}
+  '@vunk/core@1.6.1': {}
 
   '@vunk/echarts@0.0.3': {}
 


### PR DESCRIPTION
This pull request includes updates to dependencies, build configurations, and package versions across multiple files. The most significant changes involve upgrading the `@vunk/core` package, modifying build constants and external dependencies, and reorganizing imports in the `gulpfile.ts`.

### Dependency Updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L35-R35): Upgraded `@vunk/core` from version `1.5.4` to `1.6.1`.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL25-R25): Updated multiple references to `@vunk/core` from version `1.5.4` to `1.6.1` in `importers`, `packages`, and `snapshots`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL25-R25) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL45-R46) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2793-R2794) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10142-R10146) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10237-R10237)

### Build Configuration Changes:
* [`internal/build-constants/src/config.ts`](diffhunk://#diff-94bce0fe57c628b34fefbe141eea6899c0102f43ea0b84c54dc615baa6d0819dL5): Removed `echarts` from the `libExternal` array, which defines external libraries for the build process.
* [`packages/components/gulpfile.ts`](diffhunk://#diff-3def6f50c5a126989b2018eb4973ee5d4a0ebff90b6f26c4ad47d0ad2e8b783dL1-R15): Added `mermaid` and `echarts` to the `external` array, reorganized imports for better readability, and adjusted the order of imported modules. [[1]](diffhunk://#diff-3def6f50c5a126989b2018eb4973ee5d4a0ebff90b6f26c4ad47d0ad2e8b783dL1-R15) [[2]](diffhunk://#diff-3def6f50c5a126989b2018eb4973ee5d4a0ebff90b6f26c4ad47d0ad2e8b783dL40)

### Package Version Updates:
* [`packages/entry/package.json`](diffhunk://#diff-a816f0e84f2ac917c91667cb00f0db1eb98d2f9f163bcab9c1ce292b0b3d9c4aL3-R3): Incremented the version of `@vunk/markdown` from `0.0.4` to `0.0.6`.