### PR TITLE
Dev

### DIFF
--- a/docs/examples/render-tag/a.vue
+++ b/docs/examples/render-tag/a.vue
@@ -1,0 +1,41 @@
+<script lang="ts" setup>
+import type { __VkMarkdown } from '@vunk/markdown'
+import { VkMarkdown, VkRendererTemplate, VkTemplatesDefault } from '@vunk/markdown'
+import { ref } from 'vue'
+
+const currentText = ref(`
+### Link
+[Baidu](https://www.baidu.com)
+
+`)
+
+function getAttrsObj (raw: __VkMarkdown.GroupToken) {
+  return raw.open.attrs
+    ? raw.open.attrs.reduce((acc, [key, value]) => {
+      acc[key] = value
+      return acc
+    }, {} as Record<string, string>)
+    : {}
+}
+</script>
+
+<template>
+  <div h-140px>
+    <VkMarkdown :source="currentText" :tags="['a']">
+      <VkTemplatesDefault />
+
+      <VkRendererTemplate
+        type="tag:a"
+      >
+        <template #default="{ raw }">
+          <el-link
+            v-bind="getAttrsObj(raw)"
+            target="_blank"
+          >
+            {{ raw.children[0].content }}
+          </el-link>
+        </template>
+      </VkRendererTemplate>
+    </VkMarkdown>
+  </div>
+</template>

--- a/docs/pages/zh-CN/guide/render-tag/+Page.md
+++ b/docs/pages/zh-CN/guide/render-tag/+Page.md
@@ -4,12 +4,18 @@
 
 通过 **标签渲染**，你可以将传统的 HTML 元素（如表格、列表等）转换为功能更强大的交互式组件。
 
-## Basic
+## Table
 
 下面展示如何将 Markdown 表格转换为 Element Plus 的表格组件：
 
-:::demo
+<!-- :::demo
 render-tag/basic
+::: -->
+
+## A
+
+:::demo
+render-tag/a
 :::
 
 ## 使用方法

--- a/packages/components/markdown/src/utils.ts
+++ b/packages/components/markdown/src/utils.ts
@@ -23,7 +23,7 @@ export function tokensToTree (
     }
 
     if (item.children) {
-      item.children = tokensToTree(item.children as Token[])
+      item.children = tokensToTree(item.children as Token[], tags, fences)
     }
 
     if (stack.length > 0) {
@@ -48,6 +48,9 @@ export function tokensToTree (
         close: null!, // 占位，稍后补全
         children: [],
       }
+
+      console.log('开始新分组:', group, tags)
+
       if (token.type.startsWith('container_')) {
         group.templateType = `container:${token.info.split(' ')[0]}`
       }

--- a/packages/entry/package.json
+++ b/packages/entry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vunk/markdown",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "",
   "author": "EralChen",
   "license": "MIT",


### PR DESCRIPTION
This pull request introduces a new example for rendering `<a>` tags in Markdown, updates documentation to include this example, modifies the `tokensToTree` function to support additional parameters, and performs a version bump for the `@vunk/markdown` package. Below are the most significant changes grouped by theme:

### New Example and Documentation Update:
* **New `<a>` tag rendering example**: Added a new example in `docs/examples/render-tag/a.vue` to demonstrate rendering `<a>` tags in Markdown using `VkMarkdown` and `VkRendererTemplate` with Vue and Element Plus components.
* **Documentation update**: Updated `docs/pages/zh-CN/guide/render-tag/+Page.md` to include the new `<a>` tag rendering example under a new "A" section.

### Code Enhancements:
* **Enhanced `tokensToTree` function**: Modified the `tokensToTree` function in `packages/components/markdown/src/utils.ts` to accept additional parameters (`tags` and `fences`) for more flexible token processing.
* **Debugging log added**: Introduced a debugging log statement in the `tokensToTree` function to log the start of a new group and the associated tags.

### Package Update:
* **Version bump**: Updated the version of the `@vunk/markdown` package from `0.0.8` to `0.0.9` in `packages/entry/package.json`.